### PR TITLE
Add initial GPT-J support

### DIFF
--- a/mkultra/inference.py
+++ b/mkultra/inference.py
@@ -1,10 +1,11 @@
-from transformers import GPT2LMHeadModel, GPTNeoForCausalLM, TextGenerationPipeline
+from transformers import GPT2LMHeadModel, GPTNeoForCausalLM, GPTJForCausalLM, TextGenerationPipeline
 from mkultra.soft_prompt import SoftPrompt
 import torch
 
 EXTRA_ALLOWED_MODELS = [
     "GPT2SoftPromptLM",
-    "GPTNeoSoftPromptLM"
+    "GPTNeoSoftPromptLM",
+    "GPTJSoftPromptLM"
     ]
 
 for model in EXTRA_ALLOWED_MODELS:
@@ -85,5 +86,9 @@ class GPT2SoftPromptLM(GPTSoftPromptMixin, GPT2LMHeadModel):
         super().__init__(config)
 
 class GPTNeoSoftPromptLM(GPTSoftPromptMixin, GPTNeoForCausalLM):
+    def __init__(self, config):
+        super().__init__(config)
+
+class GPTJSoftPromptLM(GPTSoftPromptMixin, GPTJForCausalLM):
     def __init__(self, config):
         super().__init__(config)

--- a/mkultra/tuning.py
+++ b/mkultra/tuning.py
@@ -1,4 +1,4 @@
-from transformers import GPT2LMHeadModel, GPTNeoForCausalLM
+from transformers import GPT2LMHeadModel, GPTNeoForCausalLM, GPTJForCausalLM
 from mkultra.soft_prompt import SoftPrompt
 import torch
 import torch.nn as nn
@@ -119,5 +119,9 @@ class GPT2PromptTuningLM(GPTPromptTuningMixin, GPT2LMHeadModel):
         super().__init__(config)
 
 class GPTNeoPromptTuningLM(GPTPromptTuningMixin, GPTNeoForCausalLM):
+    def __init__(self, config):
+        super().__init__(config)
+
+class GPTJPromptTuningLM(GPTPromptTuningMixin, GPTJForCausalLM):
     def __init__(self, config):
         super().__init__(config)


### PR DESCRIPTION
I have made a quick modification to the library to implement GPT-J support. I have not tested this on the full GPT-J 6B model but I had tested it by training a softprompt on a much smaller randomly initialized version of GPT-J.